### PR TITLE
Get the payment method from order

### DIFF
--- a/Controller/Checkout/AbstractAction.php
+++ b/Controller/Checkout/AbstractAction.php
@@ -244,22 +244,6 @@ abstract class AbstractAction extends Action
     }
 
     /**
-     * @return CategoryFactory
-     */
-    protected function getCategoryFactory()
-    {
-        return $this->categoryFactory;
-    }
-
-    /**
-     * @return OrderFactory
-     */
-    protected function getOrderFactory()
-    {
-        return $this->orderFactory;
-    }
-
-    /**
      * @return LoggerInterface
      */
     protected function getLogger()
@@ -489,14 +473,6 @@ abstract class AbstractAction extends Action
         return $baseUrl . 'xendit/checkout/notification';
     }
 
-    /**
-     * @return CookieManagerInterface
-     */
-    protected function getCookieManager()
-    {
-        return $this->cookieManager;
-    }
-
     protected function getStateMultishipping()
     {
         return $this->state;
@@ -528,19 +504,26 @@ abstract class AbstractAction extends Action
     }
 
     /**
-     * @return mixed|string
+     * Get preferred payment from order
+     *
+     * @param Order $order
+     * @return false|string
      */
-    protected function getPreferredMethod()
+    protected function getPreferredMethod(Order $order)
     {
-        $preferredMethod = $this->getRequest()->getParam('preferred_method');
-        if ($preferredMethod == 'cc') {
-            $preferredMethod = 'CREDIT_CARD';
-        }
+        $payment = $order->getPayment();
+        $preferredMethod = $this->getDataHelper()->xenditPaymentMethod(
+            $payment->getMethod()
+        );
 
-        if ($preferredMethod == 'shopeepayph') {
-            $preferredMethod = 'SHOPEEPAY';
+        switch ($preferredMethod) {
+            case 'cc':
+                return 'CREDIT_CARD';
+            case 'shopeepayph':
+                return 'SHOPEEPAY';
+            default:
+                return $preferredMethod;
         }
-        return $preferredMethod;
     }
 
     /**

--- a/Controller/Checkout/Invoice.php
+++ b/Controller/Checkout/Invoice.php
@@ -52,7 +52,7 @@ class Invoice extends AbstractAction
                 'magento2_checkout',
                 [
                     'type' => 'error',
-                    'payment_method' => $this->getPreferredMethod(),
+                    'payment_method' => $this->getPreferredMethod($order),
                     'error_message' => $e->getMessage()
                 ]
             );
@@ -65,6 +65,7 @@ class Invoice extends AbstractAction
      * @param $order
      * @return array|void
      * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws LocalizedException
      */
     private function getApiRequestData($order)
     {
@@ -76,7 +77,7 @@ class Invoice extends AbstractAction
         }
 
         $orderId = $order->getRealOrderId();
-        $preferredMethod = $this->getRequest()->getParam('preferred_method');
+        $preferredMethod = $this->getPreferredMethod($order);
         $orderItems = $order->getAllItems();
         $items = [];
         foreach ($orderItems as $orderItem) {

--- a/Controller/Checkout/InvoiceMultishipping.php
+++ b/Controller/Checkout/InvoiceMultishipping.php
@@ -20,6 +20,17 @@ class InvoiceMultishipping extends AbstractAction
      */
     public function execute()
     {
+        $transactionAmount = 0;
+        $orderProcessed = false;
+        $orders = [];
+        $items = [];
+        $currency = '';
+        $billingEmail = '';
+        $customerObject = [];
+
+        $orderIncrementIds = [];
+        $preferredMethod = '';
+
         try {
             $orderIds = $this->getMultiShippingOrderIds();
             if (empty($orderIds)) {
@@ -27,17 +38,6 @@ class InvoiceMultishipping extends AbstractAction
                 $this->getLogger()->info($message);
                 return $this->redirectToCart($message);
             }
-
-            $transactionAmount = 0;
-            $orderProcessed = false;
-            $orders = [];
-            $items = [];
-            $currency = '';
-            $billingEmail = '';
-            $customerObject = [];
-
-            $orderIncrementIds = [];
-            $preferredMethod = $this->getPreferredMethod();
 
             foreach ($orderIds as $orderId) {
                 $order = $this->getOrderRepo()->get($orderId);
@@ -47,6 +47,9 @@ class InvoiceMultishipping extends AbstractAction
                     return $this->redirectToCart($message);
                 }
 
+                if (empty($preferredMethod)) {
+                    $preferredMethod = $this->getPreferredMethod($order);
+                }
                 $orderIncrementIds[] = $order->getRealOrderId();
 
                 $orderState = $order->getState();
@@ -132,7 +135,7 @@ class InvoiceMultishipping extends AbstractAction
                 'magento2_checkout',
                 [
                     'type' => 'error',
-                    'payment_method' => $this->getPreferredMethod(),
+                    'payment_method' => $preferredMethod,
                     'error_message' => $e->getMessage()
                 ]
             );

--- a/Controller/Payment/OverviewPost.php
+++ b/Controller/Payment/OverviewPost.php
@@ -142,7 +142,7 @@ class OverviewPost extends Checkout
                     );
                     $this->_redirect('*/*/billing');
                 }
-                $redirect = $baseUrl . '/xendit/checkout/invoicemultishipping?preferred_method=' . $xenditPaymentMethod;
+                $redirect = $baseUrl . '/xendit/checkout/invoicemultishipping';
                 $this->_redirect($redirect);
             } else {
                 //OTHERS


### PR DESCRIPTION
## Description

- Currently, we're using the payment method from the URL, but it causes an error if the user changes the payment on the URL. So it's better to get the payment method from the order

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Cosmetic change (text changing or color changing)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code (if necessary), particularly in hard-to-understand areas
- [ ] My changes generate no new vulnerabilities
- [ ] I have added tests that prove my fix is effective or that my feature works

## Screenshot

![Screenshot from 2023-01-05 12-13-15](https://user-images.githubusercontent.com/5335952/210706536-4fa9e99d-ad73-4a99-8212-1a4d0c0f407c.png)
![Screenshot from 2023-01-05 12-13-00](https://user-images.githubusercontent.com/5335952/210706540-2403aec4-dbd5-4a17-b1ac-b14d4f60c8c5.png)

