### PR TITLE
Fix cryptic callback response message when IP hasn't been whitelisted

### DIFF
--- a/Controller/Checkout/Notification.php
+++ b/Controller/Checkout/Notification.php
@@ -420,6 +420,10 @@ class Notification extends Action implements CsrfAwareActionInterface
 
         try {
             $invoice = $this->apiHelper->request($invoiceUrl, $invoiceMethod);
+
+            if (isset($invoice['error_code'])) {
+                throw new LocalizedException(new Phrase($invoice['message']));
+            }
         } catch (LocalizedException $e) {
             throw new LocalizedException(
                 new Phrase($e->getMessage())


### PR DESCRIPTION
<!-- Please include a summary/documentation/jira ticket of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Description

When receiving callback, if the user's server IP address hasn't been whitelisted, Xendit will get back cryptic error message that doesn't show what's wrong:

![image 3](https://github.com/xendit/xendit-magento-payment-module/assets/45989466/ee03656d-7e28-42b2-acd0-f74e6570ba9a)

One has to dig through the code, adding logs manually, to find the root issue:

![image 1](https://github.com/xendit/xendit-magento-payment-module/assets/45989466/0ca3935d-638e-4d80-8676-b730977b789c)

The process of finding the root cause can be unnecessarily time consuming. With this PR if the user's server IP hasn't been whitelisted upon receiving callback, Xendit will get back a clear response message pointing out what's wrong:

![image 2](https://github.com/xendit/xendit-magento-payment-module/assets/45989466/6366d6b9-cbd3-46bb-b2b9-1cfa04ba8c3e)

Thus users have clear indication of what's wrong just by inspecting the callback log from Xendit dashboard.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Cosmetic change (text changing or color changing)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code (if necessary), particularly in hard-to-understand areas
- [x] My changes generate no new vulnerabilities
- [ ] I have added tests that prove my fix is effective or that my feature works